### PR TITLE
add link to paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # mapping-for-linguists
-In this repository we provide the data and code for the paper "Visualizing map data for linguistics using ggplot2: A tutorial with examples from dialectology and typology". 
+
+In this repository we provide the data and code for the [paper](https://www.cambridge.org/core/journals/journal-of-linguistic-geography/article/visualizing-map-data-for-linguistics-using-ggplot2-a-tutorial-with-examples-from-dialectology-and-typology/369F9643F85781AAAC0096D6BD146215) "Visualizing map data for linguistics using ggplot2: A tutorial with examples from dialectology and typology". 


### PR DESCRIPTION
adding a link will help people who find this repo to navigate directly to the paper.

If you would prefer I link by DOI, I can do that instead.